### PR TITLE
refactor(evm_memory): limit max_heap_memory_size

### DIFF
--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -93,15 +93,18 @@ public:
         return true;
     }
 
-    void resize(size_t new_size) {
+    bool resize(size_t new_size) {
         used_ptr = begin + new_size;
 
         // out of bounds
-        if (used_ptr > end) throw std::overflow_error("out-of-memory");
-        // TODO: return EVMC_OUT_OF_MEMORY
+        if (used_ptr > end) {
+            return false;
+            // throw std::overflow_error("out-of-memory");
+        }
 
         // TODO: try to allocate more memory to m_memory
         // and catch OUT_OF_MEMORY error if failed
+        return true;
     }
 
     void clear() noexcept { used_ptr = begin; }

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -40,7 +40,7 @@ inline bool check_memory(ExecutionState& state, const uint256& offset, uint64_t 
         if ((state.gas_left -= cost) < 0)
             return false;
 
-        state.memory.resize(static_cast<size_t>(new_words * word_size));
+        return state.memory.resize(static_cast<size_t>(new_words * word_size));
     }
 
     return true;

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -23,6 +23,7 @@ inline constexpr int64_t num_words(uint64_t size_in_bytes) noexcept
 
 inline bool check_memory(ExecutionState& state, const uint256& offset, uint64_t size) noexcept
 {
+    // TODO: redefine max_buffer_size
     if (offset > max_buffer_size)
         return false;
 


### PR DESCRIPTION
since there is only 1 MB heap memory to run contracts in CKB VM